### PR TITLE
Do not show scrollbar in the community timeline on the about page

### DIFF
--- a/app/javascript/mastodon/components/status_list.js
+++ b/app/javascript/mastodon/components/status_list.js
@@ -9,6 +9,7 @@ import ImmutablePureComponent from 'react-immutable-pure-component';
 class StatusList extends ImmutablePureComponent {
 
   static propTypes = {
+    scrollable: PropTypes.bool,
     scrollKey: PropTypes.string.isRequired,
     statusIds: ImmutablePropTypes.list.isRequired,
     onScrollToBottom: PropTypes.func,
@@ -146,7 +147,7 @@ class StatusList extends ImmutablePureComponent {
   }
 
   render () {
-    const { statusIds, onScrollToBottom, scrollKey, shouldUpdateScroll, isLoading, isUnread, hasMore, prepend, emptyMessage, squareMedia, expandMedia, standalone } = this.props;
+    const { statusIds, onScrollToBottom, scrollable, scrollKey, shouldUpdateScroll, isLoading, isUnread, hasMore, prepend, emptyMessage, squareMedia, expandMedia, standalone } = this.props;
     const { isIntersecting } = this.state;
 
     let loadMore       = null;
@@ -163,7 +164,7 @@ class StatusList extends ImmutablePureComponent {
 
     if (isLoading || statusIds.size > 0 || !emptyMessage) {
       scrollableArea = (
-        <div className='scrollable' ref={this.setRef}>
+        <div className={scrollable ? 'scrollable' : ''} ref={this.setRef}>
           {unread}
 
           <div className='status-list'>

--- a/app/javascript/mastodon/features/community_timeline/index.js
+++ b/app/javascript/mastodon/features/community_timeline/index.js
@@ -34,6 +34,7 @@ class CommunityTimeline extends React.PureComponent {
     streamingAPIBaseURL: PropTypes.string.isRequired,
     accessToken: PropTypes.string.isRequired,
     hasUnread: PropTypes.bool,
+    scrollable: PropTypes.bool,
     standalone: PropTypes.bool,
   };
 

--- a/app/javascript/mastodon/features/ui/containers/status_list_container.js
+++ b/app/javascript/mastodon/features/ui/containers/status_list_container.js
@@ -40,6 +40,7 @@ const makeMapStateToProps = () => {
   const getStatusIds = makeGetStatusIds();
 
   const mapStateToProps = (state, props) => ({
+    scrollable: props.scrollable,
     scrollKey: props.scrollKey,
     shouldUpdateScroll: props.shouldUpdateScroll,
     statusIds: getStatusIds(state, props),

--- a/app/javascript/styles/pawoo-theme/about.scss
+++ b/app/javascript/styles/pawoo-theme/about.scss
@@ -93,7 +93,6 @@
       }
 
       .about-timeline-container {
-        overflow-y: scroll;
         overflow-x: hidden;
       }
     }


### PR DESCRIPTION
I wrote the following in the commit message, but is it correct?

> It is not intended to be scrollable and scrollbar may malfunction and break the UI.

|before|after|
|--------|------|
|![before](https://user-images.githubusercontent.com/17036990/27000430-b9570fa8-4dec-11e7-8f66-2ecd89f2567f.png)|![after](https://user-images.githubusercontent.com/17036990/27000431-ba786f58-4dec-11e7-86f4-e6c5446da393.png)|

EDIT: They are rendered with `Mozilla/5.0 (X11; Linux x86_64; rv:53.0) Gecko/20100101 Firefox/53.0`.