### PR TITLE
Fix excess escape in title element

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -14,7 +14,7 @@
 
     %title<
       - if content_for?(:page_title)
-        = "#{yield(:page_title).delete("\n")} - #{title}"
+        = safe_join([yield(:page_title).delete("\n").html_safe, title], ' - ')
       - else
         = title
 


### PR DESCRIPTION
![screenshot on Pawoo](https://user-images.githubusercontent.com/12539/29800832-1de2aba0-8ca7-11e7-80ec-fb40db6783e2.png)

🤔