### PR TITLE
音声付き動画がめり込んでいるのを修正

### DIFF
--- a/app/javascript/styles/stream_entries.scss
+++ b/app/javascript/styles/stream_entries.scss
@@ -267,7 +267,6 @@
         width: 100%;
         height: 100%;
         object-fit: cover;
-        top: 50%;
       }
     }
   }


### PR DESCRIPTION
https://pawoo.net/@pacochi/9050489
こういう感じのページで、音声付きの動画が半分下にめり込んでいました。
何らかの変更を行った際に削除し忘れたと思しき部分を削除して、めり込まないようにしました。
よろしくお願いします。