### PR TITLE
Moveアクティビティへの対応

### DIFF
--- a/app/lib/activitypub/activity.rb
+++ b/app/lib/activitypub/activity.rb
@@ -50,6 +50,8 @@ class ActivityPub::Activity
         ActivityPub::Activity::Add
       when 'Remove'
         ActivityPub::Activity::Remove
+      when 'Move'
+        ActivityPub::Activity::Move
       end
     end
   end

--- a/app/lib/activitypub/activity/move.rb
+++ b/app/lib/activitypub/activity/move.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+class ActivityPub::Activity::Move < ActivityPub::Activity
+  PROCESSING_COOLDOWN = 7.days.seconds
+
+  def perform
+    return if origin_account.uri != object_uri || processed?
+
+    mark_as_processing!
+
+    target_account = ActivityPub::FetchRemoteAccountService.new.call(target_uri)
+
+    return if target_account.nil? || !target_account.also_known_as.include?(origin_account.uri)
+
+    # In case for some reason we didn't have a redirect for the profile already, set it
+    origin_account.update(moved_to_account: target_account) if origin_account.moved_to_account_id.nil?
+
+    # Initiate a re-follow for each follower
+    origin_account.followers.local.select(:id).find_in_batches do |follower_accounts|
+      UnfollowFollowWorker.push_bulk(follower_accounts.map(&:id)) do |follower_account_id|
+        [follower_account_id, origin_account.id, target_account.id]
+      end
+    end
+  end
+
+  private
+
+  def origin_account
+    @account
+  end
+
+  def target_uri
+    value_or_id(@json['target'])
+  end
+
+  def processed?
+    redis.exists("move_in_progress:#{@account.id}")
+  end
+
+  def mark_as_processing!
+    redis.setex("move_in_progress:#{@account.id}", PROCESSING_COOLDOWN, true)
+  end
+end

--- a/app/lib/activitypub/adapter.rb
+++ b/app/lib/activitypub/adapter.rb
@@ -10,6 +10,7 @@ class ActivityPub::Adapter < ActiveModelSerializers::Adapter::Base
         'manuallyApprovesFollowers' => 'as:manuallyApprovesFollowers',
         'sensitive'                 => 'as:sensitive',
         'movedTo'                   => 'as:movedTo',
+        'alsoKnownAs'               => { '@id' => 'as:alsoKnownAs', '@type' => '@id' },
         'Hashtag'                   => 'as:Hashtag',
         'ostatus'                   => 'http://ostatus.org#',
         'atomUri'                   => 'ostatus:atomUri',

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -46,6 +46,7 @@
 #  featured_collection_url :string
 #  fields                  :jsonb
 #  actor_type              :string
+#  also_known_as           :string           is an Array
 #
 
 class Account < ApplicationRecord
@@ -211,6 +212,10 @@ class Account < ApplicationRecord
 
   def keypair
     @keypair ||= OpenSSL::PKey::RSA.new(private_key || public_key)
+  end
+
+  def also_known_as
+    self[:also_known_as] || []
   end
 
   def fields

--- a/app/serializers/activitypub/actor_serializer.rb
+++ b/app/serializers/activitypub/actor_serializer.rb
@@ -14,6 +14,7 @@ class ActivityPub::ActorSerializer < ActiveModel::Serializer
   has_many :virtual_attachments, key: :attachment
 
   attribute :moved_to, if: :moved?
+  attribute :also_known_as, if: :also_known_as?
 
   class EndpointsSerializer < ActiveModel::Serializer
     include RoutingHelper
@@ -114,6 +115,10 @@ class ActivityPub::ActorSerializer < ActiveModel::Serializer
 
   def moved_to
     ActivityPub::TagManager.instance.uri_for(object.moved_to_account)
+  end
+
+  def also_known_as?
+    !object.also_known_as.empty?
   end
 
   class CustomEmojiSerializer < ActivityPub::EmojiSerializer

--- a/app/services/activitypub/process_account_service.rb
+++ b/app/services/activitypub/process_account_service.rb
@@ -73,6 +73,7 @@ class ActivityPub::ProcessAccountService < BaseService
     @account.note                    = @json['summary'] || ''
     @account.locked                  = @json['manuallyApprovesFollowers'] || false
     @account.fields                  = property_values || {}
+    @account.also_known_as           = as_array(@json['alsoKnownAs'] || []).map { |item| value_or_id(item) }
     @account.actor_type              = actor_type
   end
 

--- a/app/services/follow_service.rb
+++ b/app/services/follow_service.rb
@@ -12,7 +12,7 @@ class FollowService < BaseService
     target_account = uri.is_a?(Account) ? uri : ResolveAccountService.new.call(uri)
 
     raise ActiveRecord::RecordNotFound if target_account.nil? || target_account.id == source_account.id || target_account.suspended?
-    raise Mastodon::NotPermittedError  if target_account.blocking?(source_account) || source_account.blocking?(target_account)
+    raise Mastodon::NotPermittedError  if target_account.blocking?(source_account) || source_account.blocking?(target_account) || target_account.moved?
 
     if source_account.following?(target_account)
       # We're already following this account, but we'll call follow! again to

--- a/app/workers/unfollow_follow_worker.rb
+++ b/app/workers/unfollow_follow_worker.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class UnfollowFollowWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: 'pull'
+
+  def perform(follower_account_id, old_target_account_id, new_target_account_id)
+    follower_account   = Account.find(follower_account_id)
+    old_target_account = Account.find(old_target_account_id)
+    new_target_account = Account.find(new_target_account_id)
+
+    UnfollowService.new.call(follower_account, old_target_account)
+    FollowService.new.call(follower_account, new_target_account)
+  rescue ActiveRecord::RecordNotFound
+    true
+  end
+end

--- a/app/workers/unfollow_follow_worker.rb
+++ b/app/workers/unfollow_follow_worker.rb
@@ -10,9 +10,9 @@ class UnfollowFollowWorker
     old_target_account = Account.find(old_target_account_id)
     new_target_account = Account.find(new_target_account_id)
 
-    UnfollowService.new.call(follower_account, old_target_account)
     FollowService.new.call(follower_account, new_target_account)
-  rescue ActiveRecord::RecordNotFound
+    UnfollowService.new.call(follower_account, old_target_account, skip_unmerge: true)
+  rescue ActiveRecord::RecordNotFound, Mastodon::NotPermittedError
     true
   end
 end

--- a/db/migrate/20181226021420_add_also_known_as_to_accounts.rb
+++ b/db/migrate/20181226021420_add_also_known_as_to_accounts.rb
@@ -1,0 +1,5 @@
+class AddAlsoKnownAsToAccounts < ActiveRecord::Migration[5.2]
+  def change
+    add_column :accounts, :also_known_as, :string, array: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -76,6 +76,7 @@ ActiveRecord::Schema.define(version: 2019_09_17_213523) do
     t.string "featured_collection_url"
     t.jsonb "fields"
     t.string "actor_type"
+    t.string "also_known_as", array: true
     t.index "(((setweight(to_tsvector('simple'::regconfig, (display_name)::text), 'A'::\"char\") || setweight(to_tsvector('simple'::regconfig, (username)::text), 'B'::\"char\")) || setweight(to_tsvector('simple'::regconfig, (COALESCE(domain, ''::character varying))::text), 'C'::\"char\")))", name: "search_index", using: :gin
     t.index "lower((username)::text), lower((domain)::text)", name: "index_accounts_on_username_and_domain_lower"
     t.index ["uri"], name: "index_accounts_on_uri"

--- a/spec/lib/activitypub/activity/move_spec.rb
+++ b/spec/lib/activitypub/activity/move_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe ActivityPub::Activity::Move do
+  let(:follower)    { Fabricate(:account) }
+  let(:old_account) { Fabricate(:account) }
+  let(:new_account) { Fabricate(:account) }
+
+  before do
+    follower.follow!(old_account)
+
+    old_account.update!(uri: 'https://example.org/alice', domain: 'example.org', protocol: :activitypub, inbox_url: 'https://example.org/inbox')
+    new_account.update!(uri: 'https://example.com/alice', domain: 'example.com', protocol: :activitypub, inbox_url: 'https://example.com/inbox', also_known_as: [old_account.uri])
+
+    stub_request(:post, 'https://example.org/inbox').to_return(status: 200)
+    stub_request(:post, 'https://example.com/inbox').to_return(status: 200)
+
+    service_stub = double
+    allow(ActivityPub::FetchRemoteAccountService).to receive(:new).and_return(service_stub)
+    allow(service_stub).to receive(:call).and_return(new_account)
+  end
+
+  let(:json) do
+    {
+      '@context': 'https://www.w3.org/ns/activitystreams',
+      id: 'foo',
+      type: 'Move',
+      actor: old_account.uri,
+      object: old_account.uri,
+      target: new_account.uri,
+    }.with_indifferent_access
+  end
+
+  describe '#perform' do
+    subject { described_class.new(json, old_account) }
+
+    before do
+      subject.perform
+    end
+
+    it 'sets moved account on old account' do
+      expect(old_account.reload.moved_to_account_id).to eq new_account.id
+    end
+
+    it 'makes followers unfollow old account' do
+      expect(follower.following?(old_account)).to be false
+    end
+
+    it 'makes followers follow-request the new account' do
+      expect(follower.requested?(new_account)).to be true
+    end
+  end
+end


### PR DESCRIPTION
Mastodon v3.0に搭載されるアカウントの引っ越し機能をサポートするために、連合するサーバに必要とされるコード（Moveアクティビティのハンドラ）のバックポートです。

Pawooユーザーのフォロイーがアカウントを引っ越した場合に、自動的にフォロー解除＆引っ越し先の新アカウントをフォローします。

アカウントを引っ越すユーザーにとっては、Pawooにいるフォロワーを新しいアカウントに連れて行くことができるようになります。

双方のメリットと相互運用性の確保のため、適用いただけるとありがたいです。